### PR TITLE
Fix: exports.module.default does not exist

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,6 @@ export { ono };
 export default ono;
 
 // CommonJS default export hack
-if (typeof module === "object" && typeof module.exports === "object" && typeof module.exports.default == "object") {
+if (typeof module === "object" && typeof module.exports === "object") {
   module.exports = Object.assign(module.exports.default, module.exports);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,6 @@ export { ono };
 export default ono;
 
 // CommonJS default export hack
-if (typeof module === "object" && typeof module.exports === "object") {
+if (typeof module === "object" && typeof module.exports === "object" && typeof module.exports.default == "object") {
   module.exports = Object.assign(module.exports.default, module.exports);
 }


### PR DESCRIPTION
This PR fixes a tiny bug where `module.exports` exists but `module.exports.default` does not. An additional check is added to the conditional before proceeding.